### PR TITLE
Fixed an image copy issue in powershell script

### DIFF
--- a/RegisterPluginAndStartStreamDeck.ps1
+++ b/RegisterPluginAndStartStreamDeck.ps1
@@ -13,8 +13,7 @@ $pluginName = split-path $PSScriptRoot -leaf
 
 Get-Process StreamDeck,$pluginName | Stop-Process –force -ErrorAction SilentlyContinue 
 
-mkdir $destDir -ErrorAction SilentlyContinue
-Get-ChildItem -Path $bindir -Recurse | ? { $_.FullName -inotmatch '.vs' } | Copy-Item -Destination $destDir
+Copy-Item -Path $bindir -Exclude '.vs' -Recurse -Destination $destDir -Force
 
 Write-Host "Script Completed"
 


### PR DESCRIPTION
targeting #1 

The issue was in the piping of information from one command to the other Powershell was somehow losing the sub files in images directory(i'm trying to workout why). This simplification of the commands on line 16 and 17 to one copy-item command in my opinion makes the ps1 easier to read.