### PR TITLE
Fixed issue Where the StreamDeck process was not Exiting correctly from the Power shell script

### DIFF
--- a/RegisterPluginAndStartStreamDeck.ps1
+++ b/RegisterPluginAndStartStreamDeck.ps1
@@ -11,7 +11,7 @@ $destDir = $env:APPDATA + "\Elgato\StreamDeck\Plugins\" + $pluginID + ".sdPlugin
 
 $pluginName = split-path $PSScriptRoot -leaf
 
-Get-Process StreamDeck,$pluginName | Stop-Process –force -ErrorAction SilentlyContinue 
+Get-Process StreamDeck | Stop-Process –force -ErrorAction SilentlyContinue 
 
 Copy-Item -Path $bindir -Exclude '.vs' -Recurse -Destination $destDir -Force
 

--- a/RegisterPluginAndStartStreamDeck.ps1
+++ b/RegisterPluginAndStartStreamDeck.ps1
@@ -13,8 +13,7 @@ $pluginName = split-path $PSScriptRoot -leaf
 
 Get-Process StreamDeck,$pluginName | Stop-Process –force -ErrorAction SilentlyContinue 
 
-mkdir $destDir -ErrorAction SilentlyContinue
-Get-ChildItem -Path $bindir -Recurse | ? { $_.FullName -inotmatch '.vs' } | Copy-Item -Destination $destDir
+Copy-Item -Path $bindir -Exclude '.vs' -Recurse -Destination $destDir -Force
 
 Write-Host "Script Completed"
 


### PR DESCRIPTION
Targeting #3 

line 14 reads:

Get-Process StreamDeck,$pluginName | Stop-Process –force -ErrorAction SilentlyContinue 

This does not collect the correct StreamDeck process so you can end up with multiple copies of StreamDeck running and locked files.

To correct this I changed line 14 to read:

Get-Process StreamDeck | Stop-Process -force -ErrorAction SilentlyContinue

This will automatically shutdown all plugins allowing for a clean restart of the StreamDeck Application and its plugins. 

